### PR TITLE
[Fixed] `rails g` コマンドの際に assets ファイル、helper が作成されないよう改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,10 @@ module Achieve
         controller_specs: true,
         request_specs: false
       g.fixture_replacement :factory_girl, dir: "spec/factories"
+
+      # DIVE22
+      g.assets     false
+      g.helper     false
     end
   end
 end


### PR DESCRIPTION
#1 

`rails g` コマンドの際に assets ファイル、helper が作成されないように、config/application.rb ファイルを変更。